### PR TITLE
Add nullable wrapper to data generators

### DIFF
--- a/internal/generators/datetime.go
+++ b/internal/generators/datetime.go
@@ -2,10 +2,11 @@ package generators
 
 import (
 	"fmt"
-	"github.com/bitstonks/syndi/internal/config"
 	"log"
 	"math/rand"
 	"time"
+
+	"github.com/bitstonks/syndi/internal/config"
 )
 
 func NewDatetimeNowGenerator(args config.Args) Generator {
@@ -14,43 +15,39 @@ func NewDatetimeNowGenerator(args config.Args) Generator {
 }
 
 type DatetimeUniformGenerator struct {
-	rng      *rand.Rand
-	dtFmt    string
-	nullable float64
-	minVal   int64
-	maxVal   int64
+	rng    *rand.Rand
+	dtFmt  string
+	minVal int64
+	spread int64
 }
 
 func NewDatetimeUniformGenerator(args config.Args) Generator {
 	g := DatetimeUniformGenerator{
-		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
-		dtFmt:    "2006-01-02 15:04:05",
-		nullable: args.Nullable,
+		rng:   NewRng(),
+		dtFmt: "2006-01-02 15:04:05",
 	}
-	minVal := time.Date(1970, 1, 0, 0, 0, 0, 0, time.UTC)
-	maxVal := time.Now().UTC()
-	g.minVal = parseDT(g.dtFmt, args.MinVal, minVal).Unix()
-	g.maxVal = parseDT(g.dtFmt, args.MaxVal, maxVal).Unix()
-	if g.minVal >= g.maxVal {
+	minVal := time.Date(1970, 1, 0, 0, 0, 0, 0, time.UTC).Unix()
+	maxVal := time.Now().UTC().Unix()
+	minVal = parseDT(g.dtFmt, args.MinVal, minVal)
+	maxVal = parseDT(g.dtFmt, args.MaxVal, maxVal)
+	if minVal >= maxVal {
 		log.Panicf(
 			"minVal not smaller than maxVal: %s < %s",
-			time.Unix(g.minVal, 0).Format(g.dtFmt),
-			time.Unix(g.maxVal, 0).Format(g.dtFmt),
+			time.Unix(minVal, 0).Format(g.dtFmt),
+			time.Unix(maxVal, 0).Format(g.dtFmt),
 		)
 	}
+	g.minVal = minVal
+	g.spread = maxVal - minVal
 	return &g
 }
 
 func (g *DatetimeUniformGenerator) Next() string {
-	if g.nullable > 0 && g.rng.Float64() < g.nullable {
-		return "NULL"
-	}
-
-	secs := g.rng.Int63n(g.maxVal-g.minVal) + g.minVal
+	secs := g.rng.Int63n(g.spread) + g.minVal
 	return fmt.Sprintf("%q", time.Unix(secs, 0).Format(g.dtFmt))
 }
 
-func parseDT(dtFmt, dt string, fallback time.Time) time.Time {
+func parseDT(dtFmt, dt string, fallback int64) int64 {
 	if len(dt) == 0 {
 		return fallback
 	}
@@ -58,5 +55,5 @@ func parseDT(dtFmt, dt string, fallback time.Time) time.Time {
 	if err != nil {
 		log.Panicf("error parsing datetime %q: %s", dt, err)
 	}
-	return v
+	return v.Unix()
 }

--- a/internal/generators/float.go
+++ b/internal/generators/float.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"math/rand"
 	"strconv"
-	"time"
 
 	"github.com/bitstonks/syndi/internal/config"
 )
@@ -26,35 +25,29 @@ func parseMinMaxFloat(args *config.Args) (float64, float64) {
 }
 
 type FloatUniformGenerator struct {
-	rng      *rand.Rand
-	nullable float64
-	minVal   float64
-	maxVal   float64
+	rng    *rand.Rand
+	minVal float64
+	spread float64
 }
 
 func NewFloatUniformGenerator(args config.Args) Generator {
 	minVal, maxVal := parseMinMaxFloat(&args)
 	return &FloatUniformGenerator{
-		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
-		nullable: args.Nullable,
-		minVal:   minVal,
-		maxVal:   maxVal,
+		rng:    NewRng(),
+		minVal: minVal,
+		spread: maxVal - minVal,
 	}
 }
 
 func (g *FloatUniformGenerator) Next() string {
-	if g.nullable > 0 && g.rng.Float64() < g.nullable {
-		return "NULL"
-	}
-	v := g.minVal + g.rng.Float64()*(g.maxVal-g.minVal)
+	v := g.minVal + g.rng.Float64()*g.spread
 	return fmt.Sprintf("%g", v)
 }
 
 type FloatNormalGenerator struct {
-	rng      *rand.Rand
-	nullable float64
-	mean     float64
-	stDev    float64
+	rng   *rand.Rand
+	mean  float64
+	stDev float64
 }
 
 // Creates a random float generator with a normal distribution
@@ -63,25 +56,20 @@ type FloatNormalGenerator struct {
 func NewFloatNormalGenerator(args config.Args) Generator {
 	minVal, maxVal := parseMinMaxFloat(&args)
 	return &FloatNormalGenerator{
-		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
-		nullable: args.Nullable,
-		mean:     (maxVal + minVal) / 2,
-		stDev:    (maxVal - minVal) / 2,
+		rng:   NewRng(),
+		mean:  (maxVal + minVal) / 2,
+		stDev: (maxVal - minVal) / 2,
 	}
 }
 
 func (g *FloatNormalGenerator) Next() string {
-	if g.nullable > 0 && g.rng.Float64() < g.nullable {
-		return "NULL"
-	}
 	return fmt.Sprintf("%g", g.rng.NormFloat64()*g.stDev+g.mean)
 }
 
 type FloatExpGenerator struct {
-	rng      *rand.Rand
-	nullable float64
-	minVal   float64
-	mean     float64
+	rng    *rand.Rand
+	minVal float64
+	mean   float64
 }
 
 // Creates a random float generator with exponential distribution
@@ -91,16 +79,12 @@ type FloatExpGenerator struct {
 func NewFloatExpGenerator(args config.Args) Generator {
 	minVal, maxVal := parseMinMaxFloat(&args)
 	return &FloatExpGenerator{
-		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
-		nullable: args.Nullable,
-		minVal:   minVal,
-		mean:     (maxVal - minVal) / 2,
+		rng:    NewRng(),
+		minVal: minVal,
+		mean:   (maxVal - minVal) / 2,
 	}
 }
 
 func (g *FloatExpGenerator) Next() string {
-	if g.nullable > 0 && g.rng.Float64() < g.nullable {
-		return "NULL"
-	}
 	return fmt.Sprintf("%g", g.rng.ExpFloat64()*g.mean+g.minVal)
 }

--- a/internal/generators/generators.go
+++ b/internal/generators/generators.go
@@ -2,6 +2,9 @@ package generators
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
+
 	"github.com/bitstonks/syndi/internal/config"
 )
 
@@ -20,7 +23,7 @@ func GetGenerator(args config.Args) (Generator, error) {
 	if !ok {
 		return nil, fmt.Errorf("generator of type %s doesn't exist", args.Type)
 	}
-	return builder(args), nil
+	return MakeNullable(builder(args), args.Nullable), nil
 }
 
 func init() {
@@ -47,4 +50,8 @@ func init() {
 	RegisterGenerator("string/rand", NewStringGenerator)
 	RegisterGenerator("string/text", NewTextGenerator)
 	RegisterGenerator("string/uuid", NewUuidGenerator)
+}
+
+func NewRng() *rand.Rand {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
 }

--- a/internal/generators/int.go
+++ b/internal/generators/int.go
@@ -2,18 +2,17 @@ package generators
 
 import (
 	"fmt"
-	"github.com/bitstonks/syndi/internal/config"
 	"log"
 	"math/rand"
 	"strconv"
-	"time"
+
+	"github.com/bitstonks/syndi/internal/config"
 )
 
 type IntUniformGenerator struct {
-	rng      *rand.Rand
-	nullable float64
-	minVal   int // Inclusive
-	maxVal   int // Non-inclusive
+	rng    *rand.Rand
+	minVal int // Inclusive
+	spread int // minVal + spread non-inclusive
 }
 
 func NewIntUniformGenerator(args config.Args) Generator {
@@ -29,16 +28,12 @@ func NewIntUniformGenerator(args config.Args) Generator {
 		log.Panicf("minVal not smaller than maxVal: %d < %d", minVal, maxVal)
 	}
 	return &IntUniformGenerator{
-		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
-		nullable: args.Nullable,
-		minVal:   int(minVal),
-		maxVal:   int(maxVal),
+		rng:    NewRng(),
+		minVal: int(minVal),
+		spread: int(maxVal - minVal),
 	}
 }
 
 func (g *IntUniformGenerator) Next() string {
-	if g.nullable > 0 && g.rng.Float64() < g.nullable {
-		return "NULL"
-	}
-	return fmt.Sprintf("%d", g.rng.Intn(g.maxVal-g.minVal)+g.minVal)
+	return fmt.Sprintf("%d", g.rng.Intn(g.spread)+g.minVal)
 }

--- a/internal/generators/nullable.go
+++ b/internal/generators/nullable.go
@@ -1,0 +1,29 @@
+package generators
+
+import (
+	"math/rand"
+)
+
+type Nullable struct {
+	rng      *rand.Rand
+	nullable float64
+	gen      Generator
+}
+
+func MakeNullable(gen Generator, nullable float64) Generator {
+	if nullable <= 0 {
+		return gen
+	}
+	return &Nullable{
+		rng:      NewRng(),
+		nullable: nullable,
+		gen:      gen,
+	}
+}
+
+func (n *Nullable) Next() string {
+	if n.rng.Float64() < n.nullable {
+		return "NULL"
+	}
+	return n.gen.Next()
+}

--- a/internal/generators/oneof.go
+++ b/internal/generators/oneof.go
@@ -1,19 +1,18 @@
 package generators
 
 import (
-	"github.com/bitstonks/syndi/internal/config"
 	"log"
 	"math/rand"
 	"strconv"
 	"strings"
-	"time"
+
+	"github.com/bitstonks/syndi/internal/config"
 )
 
 type OneOfGenerator struct {
-	rng      *rand.Rand
-	nullable float64
-	weights  map[string]int
-	total    int
+	rng     *rand.Rand
+	weights map[string]int
+	total   int
 }
 
 func NewOneOfGenerator(args config.Args) Generator {
@@ -23,17 +22,13 @@ func NewOneOfGenerator(args config.Args) Generator {
 		total += w
 	}
 	return &OneOfGenerator{
-		nullable: args.Nullable,
-		weights:  weights,
-		total:    total,
-		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
+		rng:     NewRng(),
+		weights: weights,
+		total:   total,
 	}
 }
 
 func (g *OneOfGenerator) Next() string {
-	if g.nullable > 0 && g.rng.Float64() < g.nullable {
-		return "NULL"
-	}
 	n := g.rng.Intn(g.total)
 	for v, w := range g.weights {
 		n -= w

--- a/internal/generators/string.go
+++ b/internal/generators/string.go
@@ -1,33 +1,28 @@
 package generators
 
 import (
-	"github.com/bitstonks/syndi/internal/config"
 	"math/rand"
-	"time"
+
+	"github.com/bitstonks/syndi/internal/config"
 )
 
 // yaay, globals!
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
 type StringGenerator struct {
-	rng      *rand.Rand
-	len      int
-	nullable float64
+	rng *rand.Rand
+	len int
 }
 
 func NewStringGenerator(args config.Args) Generator {
 	// TODO: when defined use args.OneOf for character selection instead of global letters
 	return &StringGenerator{
-		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
-		nullable: args.Nullable,
-		len:      args.Length,
+		rng: NewRng(),
+		len: args.Length,
 	}
 }
 
 func (g *StringGenerator) Next() string {
-	if g.nullable > 0 && g.rng.Float64() < g.nullable {
-		return "NULL"
-	}
 	b := make([]rune, g.len)
 	for i := range b {
 		b[i] = letters[g.rng.Intn(len(letters))]

--- a/internal/generators/text.go
+++ b/internal/generators/text.go
@@ -2,10 +2,10 @@ package generators
 
 import (
 	"fmt"
-	"github.com/bitstonks/syndi/internal/config"
 	"math/rand"
 	"strings"
-	"time"
+
+	"github.com/bitstonks/syndi/internal/config"
 )
 
 // yaay, globals!
@@ -35,23 +35,18 @@ var lipsumLen = len(lipsum)
 
 // TODO: what if Len is actually greater than lipsumLen?
 type TextGenerator struct {
-	rng      *rand.Rand
-	len      int
-	nullable float64
+	rng *rand.Rand
+	len int
 }
 
 func NewTextGenerator(args config.Args) Generator {
 	return &TextGenerator{
-		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
-		len:      args.Length,
-		nullable: args.Nullable,
+		rng: NewRng(),
+		len: args.Length,
 	}
 }
 
 func (g *TextGenerator) Next() string {
-	if g.nullable > 0 && g.rng.Float64() < g.nullable {
-		return "NULL"
-	}
 	i := g.rng.Intn(lipsumLen - g.len)
 	return fmt.Sprintf("%q", lipsum[i:i+g.len])
 }

--- a/internal/generators/uuid.go
+++ b/internal/generators/uuid.go
@@ -2,31 +2,18 @@ package generators
 
 import (
 	"fmt"
+
 	"github.com/bitstonks/syndi/internal/config"
 	"github.com/google/uuid"
-	"math/rand"
-	"time"
 )
 
-type UuidGenerator struct {
-	rng      *rand.Rand
-	nullable float64
-}
+type UuidGenerator struct{}
 
 // TODO: add length?
 func NewUuidGenerator(args config.Args) Generator {
-	g := UuidGenerator{
-		nullable: args.Nullable,
-	}
-	if g.nullable > 0 {
-		g.rng = rand.New(rand.NewSource(time.Now().UnixNano()))
-	}
-	return &g
+	return &UuidGenerator{}
 }
 
 func (g *UuidGenerator) Next() string {
-	if g.nullable > 0 && g.rng.Float64() < g.nullable {
-		return "NULL"
-	}
 	return fmt.Sprintf("%q", uuid.NewString())
 }


### PR DESCRIPTION
Instead of each generator dealing with a nullable
option use a Nullable wrapper instead. That way each
object has a single responsibility and should be
easier understand and hopefully test in the future.

Additionally I got tired of constructing random number
generators so I created a constructor for that.