### PR TITLE
Update command run arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ can choose integers from a range of predefined values that will serve as some co
 
 Data definitions are specified via a YAML config file, one config is (currently) bound to a single database table.
 
+## Usage
+
+Clone the repo and compile the binary. The `-h` command-line flag hints at possible parameters
+```shell
+$ ./syndi -h
+...
+```
+
+You must pass at least one table definition YAML file, for example.
+```shell
+$ ./syndi users.yaml
+```
+
+See `test/testdata/config-example.yaml` and generator definitions in the next paragraph for details.
+
 ## Available data generators
 
 > **_NOTE:_** this list was up-to-date at the time of writing but might not be at the time of you reading it.

--- a/cmd/syndi/main.go
+++ b/cmd/syndi/main.go
@@ -11,21 +11,28 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 )
 
-var configFile = flag.String("c", "config.yaml", "configuration file to use")
-
 // TODO 1: generate in one goroutine and import in another...
 // TODO 2: have concurrent clients for faster import...
 func main() {
+	// save command-line arguments
+	args := config.RunArgs{}
+	flag.StringVar(&args.Database, "db", "bitstamp_dev", "Database name to use")
+	flag.StringVar(&args.Host, "host", "localhost", "Database host to connect to")
+	flag.StringVar(&args.Password, "p", "root", "Database user's password")
+	flag.StringVar(&args.Port, "P", "28000", "Database port number")
+	flag.BoolVar(&args.Safe, "safe", false, "Whether foreign key checks are mandated")
+	flag.StringVar(&args.User, "u", "root", "Database user")
 	flag.Parse()
+	args.Tables = flag.Args()
 
 	// load configuration
-	cfg, err := config.LoadConfig(*configFile)
+	dbDSN, tableDefinitions, err := config.LoadConfig(args)
 	if err != nil {
-		log.Panicf("error loading config file (%s): %#v:", *configFile, err)
+		log.Panicf("error loading config: %#v:", err)
 	}
 
 	// connect to db
-	db, err := sql.Open("mysql", cfg.DbDSN)
+	db, err := sql.Open("mysql", dbDSN)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -35,15 +42,18 @@ func main() {
 		log.Panic(err)
 	}
 
-	im := importer.NewImporter(db, cfg)
-	err = im.DisableFK()
-	if err != nil {
-		log.Panic(err)
-	}
-	defer im.EnableFK()
+	// import things
+	for _, tableDef := range tableDefinitions {
+		im := importer.NewImporter(db, tableDef)
+		err = im.DisableFK()
+		if err != nil {
+			log.Panic(err)
+		}
 
-	err = im.Import()
-	if err != nil {
-		log.Panic(err)
+		err = im.Import()
+		if err != nil {
+			log.Panic(err)
+		}
+		im.EnableFK() // TODO: this can now fail to run, not sure whether it is a problem since it's connection-bound (?)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,11 +42,10 @@ type ColumnDef struct {
 
 // TableDef describes one particular database table. Its data is (mostly) loaded from a YAML file.
 type TableDef struct {
-	DbDSN        string               `yaml:"DbDSN" validate:"required"`
-	DbTable      string               `yaml:"DbTable" validate:"required"`
+	TableName    string               `yaml:"TableName" validate:"required"`
 	TotalRecords int                  `yaml:"TotalRecords" validate:"required,gt=0"`
 	BatchSize    int                  `yaml:"BatchSize" validate:"required,gt=0"`
-	SafeImport   bool                 `yaml:"SafeImport"`
+	SafeImport   bool                 // TODO: should this be global?
 	Columns      map[string]ColumnDef `yaml:"Columns" validate:"required,dive,keys,required,endkeys"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,7 +30,8 @@ func (a RunArgs) GetDSN() string {
 	return dsn
 }
 
-type Args struct {
+// ColumnDef defines the type of data we want inserted into a single column of a particular database table.
+type ColumnDef struct {
 	Type     string  `yaml:"Type" validate:"required"`
 	Nullable float64 `yaml:"Nullable" validate:"optional"`
 	MinVal   string  `yaml:"MinVal" validate:"optional"`
@@ -40,12 +41,12 @@ type Args struct {
 }
 
 type Config struct {
-	DbDSN        string          `yaml:"DbDSN" validate:"required"`
-	DbTable      string          `yaml:"DbTable" validate:"required"`
-	TotalRecords int             `yaml:"TotalRecords" validate:"required,gt=0"`
-	BatchSize    int             `yaml:"BatchSize" validate:"required,gt=0"`
-	SafeImport   bool            `yaml:"SafeImport"`
-	Columns      map[string]Args `yaml:"Columns" validate:"required,dive,keys,required,endkeys"`
+	DbDSN        string               `yaml:"DbDSN" validate:"required"`
+	DbTable      string               `yaml:"DbTable" validate:"required"`
+	TotalRecords int                  `yaml:"TotalRecords" validate:"required,gt=0"`
+	BatchSize    int                  `yaml:"BatchSize" validate:"required,gt=0"`
+	SafeImport   bool                 `yaml:"SafeImport"`
+	Columns      map[string]ColumnDef `yaml:"Columns" validate:"required,dive,keys,required,endkeys"`
 }
 
 func LoadConfig(filename string) (*Config, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,11 +1,34 @@
 package config
 
 import (
+	"fmt"
 	"github.com/go-playground/validator/v10"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"log"
 )
+
+// RunArgs is a container for command-line flags passed in.
+type RunArgs struct {
+	Database string `validate:"required"`
+	Host     string `validate:"required"`
+	Password string `validate:"required"`
+	Port     string `validate:"required,number,gt=0"`
+	Safe     bool
+	Tables   []string `validate:"required,gt=0"`
+	User     string   `validate:"required"`
+}
+
+func (a RunArgs) GetDSN() string {
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true&interpolateParams=true",
+		a.User,
+		a.Password,
+		a.Host,
+		a.Port,
+		a.Database,
+	)
+	return dsn
+}
 
 type Args struct {
 	Type     string  `yaml:"Type" validate:"required"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,7 +40,8 @@ type ColumnDef struct {
 	Length   int     `yaml:"Length" validate:"optional"`
 }
 
-type Config struct {
+// TableDef describes one particular database table. Its data is (mostly) loaded from a YAML file.
+type TableDef struct {
 	DbDSN        string               `yaml:"DbDSN" validate:"required"`
 	DbTable      string               `yaml:"DbTable" validate:"required"`
 	TotalRecords int                  `yaml:"TotalRecords" validate:"required,gt=0"`
@@ -49,12 +50,12 @@ type Config struct {
 	Columns      map[string]ColumnDef `yaml:"Columns" validate:"required,dive,keys,required,endkeys"`
 }
 
-func LoadConfig(filename string) (*Config, error) {
+func LoadConfig(filename string) (*TableDef, error) {
 	yamlFile, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
-	c := &Config{}
+	c := &TableDef{}
 	err = yaml.Unmarshal(yamlFile, &c)
 	if err != nil {
 		return nil, err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -68,6 +68,6 @@ func TestLoadConfig(t *testing.T) {
 	cfgPath := path.Join(currWd, "../../test/testdata/config-example.yaml")
 	cfg, err := LoadConfig(cfgPath)
 	assert.NoError(t, err)
-	assert.False(t, cfg.SafeImport)
+	assert.False(t, cfg.SafeImport) // zero value
 	assert.Equal(t, 5031, cfg.TotalRecords)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -64,10 +64,20 @@ func TestRunArgs(t *testing.T) {
 func TestLoadConfig(t *testing.T) {
 	currWd, err := os.Getwd()
 	assert.NoError(t, err)
-
 	cfgPath := path.Join(currWd, "../../test/testdata/config-example.yaml")
-	cfg, err := LoadConfig(cfgPath)
+
+	args := RunArgs{
+		Database: "example",
+		Host:     "localhost",
+		Password: "root",
+		Port:     "3306",
+		Safe:     false,
+		Tables:   []string{cfgPath},
+		User:     "root",
+	}
+
+	_, defs, err := LoadConfig(args)
 	assert.NoError(t, err)
-	assert.False(t, cfg.SafeImport) // zero value
-	assert.Equal(t, 5031, cfg.TotalRecords)
+	assert.False(t, defs[0].SafeImport) // zero value
+	assert.Equal(t, 5031, defs[0].TotalRecords)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,12 +1,65 @@
 package config
 
 import (
+	"github.com/go-playground/validator/v10"
 	"os"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestRunArgs(t *testing.T) {
+	t.Run("test initialization happy path", func(t *testing.T) {
+		args := RunArgs{
+			Database: "example",
+			Host:     "localhost",
+			Password: "root",
+			Port:     "3306",
+			Safe:     false,
+			Tables:   []string{"users.yaml", "accounts.yaml"},
+			User:     "root",
+		}
+		validate := validator.New()
+		err := validate.Struct(args)
+		assert.NoError(t, err)
+	})
+
+	t.Run("test initialization sad path", func(t *testing.T) {
+		args := RunArgs{
+			Database: "example",
+			Host:     "localhost",
+			Password: "root",
+			Port:     "invalid port number",
+			Safe:     false,
+			User:     "root",
+		}
+		validate := validator.New()
+		err := validate.Struct(args)
+		assert.EqualError(t, err, "Key: 'RunArgs.Port' Error:Field validation for 'Port' failed on the 'number' tag\nKey: 'RunArgs.Tables' Error:Field validation for 'Tables' failed on the 'required' tag")
+
+		args.Port = "3306"
+		err = validate.Struct(args)
+		assert.EqualError(t, err, "Key: 'RunArgs.Tables' Error:Field validation for 'Tables' failed on the 'required' tag")
+
+		args.Tables = []string{"users.yaml"}
+		err = validate.Struct(args)
+		assert.NoError(t, err)
+	})
+
+	t.Run("test GetDSN", func(t *testing.T) {
+		args := RunArgs{
+			Database: "example",
+			Host:     "localhost",
+			Password: "root",
+			Port:     "3306",
+			Safe:     false,
+			Tables:   []string{"users.yaml", "accounts.yaml"},
+			User:     "root",
+		}
+		assert.Equal(t, args.GetDSN(), "root:root@tcp(localhost:3306)/example?parseTime=true&interpolateParams=true")
+	})
+}
 
 func TestLoadConfig(t *testing.T) {
 	currWd, err := os.Getwd()

--- a/internal/generators/bool.go
+++ b/internal/generators/bool.go
@@ -4,7 +4,7 @@ import (
 	"github.com/bitstonks/syndi/internal/config"
 )
 
-func NewBoolGenerator(args config.Args) Generator {
+func NewBoolGenerator(args config.ColumnDef) Generator {
 	args.OneOf = "0;1"
 	return NewOneOfGenerator(args)
 }

--- a/internal/generators/bool_test.go
+++ b/internal/generators/bool_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ExampleNewBoolGenerator() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type: "bool",
 	}
 	g, _ := GetGenerator(args)
@@ -19,7 +19,7 @@ func ExampleNewBoolGenerator() {
 }
 
 func ExampleNewBoolGenerator_oneof() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type:  "bool/oneof",
 		OneOf: "0:20;1:1", // 0 has 20x probability over 1
 	}

--- a/internal/generators/datetime.go
+++ b/internal/generators/datetime.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bitstonks/syndi/internal/config"
 )
 
-func NewDatetimeNowGenerator(args config.Args) Generator {
+func NewDatetimeNowGenerator(args config.ColumnDef) Generator {
 	args.OneOf = "NOW()"
 	return NewOneOfGenerator(args)
 }
@@ -21,7 +21,7 @@ type datetimeUniformGenerator struct {
 	spread int64
 }
 
-func NewDatetimeUniformGenerator(args config.Args) Generator {
+func NewDatetimeUniformGenerator(args config.ColumnDef) Generator {
 	g := datetimeUniformGenerator{
 		rng:   newRng(),
 		dtFmt: "2006-01-02 15:04:05",

--- a/internal/generators/datetime_test.go
+++ b/internal/generators/datetime_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ExampleNewDatetimeNowGenerator() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type: "datetime", // alias for "datetime/now"
 	}
 	g, _ := GetGenerator(args)
@@ -15,7 +15,7 @@ func ExampleNewDatetimeNowGenerator() {
 }
 
 func ExampleNewDatetimeUniformGenerator() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type:   "datetime/uniform",
 		MinVal: "2011-08-15 18:18:18", // Default is 1970-01-01 00:00:00
 		MaxVal: "2021-12-01 21:54:35", // Default is current time

--- a/internal/generators/float.go
+++ b/internal/generators/float.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bitstonks/syndi/internal/config"
 )
 
-func parseMinMaxFloat(args *config.Args) (float64, float64) {
+func parseMinMaxFloat(args *config.ColumnDef) (float64, float64) {
 	minVal, err := strconv.ParseFloat(args.MinVal, 64)
 	if err != nil {
 		log.Panicf("Unable to parse minVal: %s", err)
@@ -30,7 +30,7 @@ type floatUniformGenerator struct {
 	spread float64
 }
 
-func NewFloatUniformGenerator(args config.Args) Generator {
+func NewFloatUniformGenerator(args config.ColumnDef) Generator {
 	minVal, maxVal := parseMinMaxFloat(&args)
 	return &floatUniformGenerator{
 		rng:    newRng(),
@@ -53,7 +53,7 @@ type floatNormalGenerator struct {
 // Creates a random float generator with a normal distribution
 // with the mean equal to the mean of args.MinVal and args.MaxVal
 // and with both MinVal and MaxVal one stDev away from the mean.
-func NewFloatNormalGenerator(args config.Args) Generator {
+func NewFloatNormalGenerator(args config.ColumnDef) Generator {
 	minVal, maxVal := parseMinMaxFloat(&args)
 	return &floatNormalGenerator{
 		rng:   newRng(),
@@ -76,7 +76,7 @@ type floatExpGenerator struct {
 // where the minimal value is args.MinVal and the mean value is
 // (args.MinVal+args.MaxVal)/2. This means that around 15% of all
 // numbers generated will be bigger than args.MaxVal.
-func NewFloatExpGenerator(args config.Args) Generator {
+func NewFloatExpGenerator(args config.ColumnDef) Generator {
 	minVal, maxVal := parseMinMaxFloat(&args)
 	return &floatExpGenerator{
 		rng:    newRng(),

--- a/internal/generators/float_test.go
+++ b/internal/generators/float_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ExampleNewFloatUniformGenerator() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type:   "float", // alias for "float/uniform"
 		MinVal: "-1.5",
 		MaxVal: "0.36",
@@ -18,7 +18,7 @@ func ExampleNewFloatUniformGenerator() {
 }
 
 func ExampleNewFloatNormalGenerator() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type:   "float/normal",
 		MinVal: "10.0", // mean - stdev
 		MaxVal: "30.0", // mean + stdev
@@ -30,7 +30,7 @@ func ExampleNewFloatNormalGenerator() {
 }
 
 func ExampleNewFloatExpGenerator() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type:   "float/exp",
 		MinVal: "10.0",
 		MaxVal: "30.0", // MinVal + 1/lambda

--- a/internal/generators/generators.go
+++ b/internal/generators/generators.go
@@ -12,14 +12,14 @@ type Generator interface {
 	Next() string
 }
 
-var generatorBuilders map[string]func(config.Args) Generator
+var generatorBuilders map[string]func(config.ColumnDef) Generator
 
-func RegisterGenerator(genType string, builder func(config.Args) Generator) {
+func RegisterGenerator(genType string, builder func(config.ColumnDef) Generator) {
 	generatorBuilders[genType] = builder
 }
 
 // GetGenerator will find a generator matching args.Type if one was registered or return an error.
-func GetGenerator(args config.Args) (Generator, error) {
+func GetGenerator(args config.ColumnDef) (Generator, error) {
 	builder, ok := generatorBuilders[args.Type]
 	if !ok {
 		return nil, fmt.Errorf("generator of type %s doesn't exist", args.Type)
@@ -28,7 +28,7 @@ func GetGenerator(args config.Args) (Generator, error) {
 }
 
 func init() {
-	generatorBuilders = make(map[string]func(config.Args) Generator)
+	generatorBuilders = make(map[string]func(config.ColumnDef) Generator)
 	// Since the interface always uses strings we can use a unified (weighted) multiple choice random generator
 	// for all column types. We do give up on some validation by doing that.
 	// TODO: have specialized constructors that validate the data but still use OneOfGenerator behind the scenes

--- a/internal/generators/generators_test.go
+++ b/internal/generators/generators_test.go
@@ -23,7 +23,7 @@ func init() {
 	}
 }
 
-type readmeConfig map[string]config.Args
+type readmeConfig map[string]config.ColumnDef
 
 func loadConfigFromReadme() (readmeConfig, error) {
 	var confData []byte

--- a/internal/generators/int.go
+++ b/internal/generators/int.go
@@ -15,7 +15,7 @@ type intUniformGenerator struct {
 	spread int // minVal + spread non-inclusive
 }
 
-func NewIntUniformGenerator(args config.Args) Generator {
+func NewIntUniformGenerator(args config.ColumnDef) Generator {
 	minVal, err := strconv.ParseInt(args.MinVal, 10, 64)
 	if err != nil {
 		log.Panicf("Unable to parse minVal: %s", err)

--- a/internal/generators/int_test.go
+++ b/internal/generators/int_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ExampleNewIntUniformGenerator() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type:   "int", // alias for "int/uniform"
 		MinVal: "-50", // inclusive
 		MaxVal: "202", // non-inclusive

--- a/internal/generators/nullable_test.go
+++ b/internal/generators/nullable_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ExampleMakeNullable_half() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type:     "oneof",
 		OneOf:    "ok", // only possible non-null value is 'ok'
 		Nullable: 0.2,  // NULL 20% of time
@@ -20,7 +20,7 @@ func ExampleMakeNullable_half() {
 }
 
 func ExampleMakeNullable_always() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type:     "int/uniform", // uniform random number
 		MinVal:   "0",           // from including 0
 		MaxVal:   "100",         // to not including 100

--- a/internal/generators/oneof.go
+++ b/internal/generators/oneof.go
@@ -19,7 +19,7 @@ type oneOfGenerator struct {
 }
 
 // NewOneOfGenerator constructs a oneOfGenerator
-func NewOneOfGenerator(args config.Args) Generator {
+func NewOneOfGenerator(args config.ColumnDef) Generator {
 	weights, total := getMultipleChoice(args.OneOf)
 	return &oneOfGenerator{
 		rng:     newRng(),
@@ -44,7 +44,7 @@ type quotedOneOfGenerator struct {
 	gen Generator
 }
 
-func NewQuotedOneOfGenerator(args config.Args) Generator {
+func NewQuotedOneOfGenerator(args config.ColumnDef) Generator {
 	return &quotedOneOfGenerator{
 		gen: NewOneOfGenerator(args),
 	}

--- a/internal/generators/oneof_test.go
+++ b/internal/generators/oneof_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ExampleNewOneOfGenerator_uniform() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type:  "int/oneof",
 		OneOf: "1;2;4;8;16",
 	}
@@ -17,7 +17,7 @@ func ExampleNewOneOfGenerator_uniform() {
 }
 
 func ExampleNewOneOfGenerator_weighted() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type: "int/oneof",
 		// 2 is as likely as 8, but 5 is twice as likely as 2 and 10 three times as likely as 2.
 		// Weight '1' is implicitly added to choice 8. And 90 will never be picked.
@@ -30,7 +30,7 @@ func ExampleNewOneOfGenerator_weighted() {
 }
 
 func ExampleNewQuotedOneOfGenerator_uniform() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type:  "datetime/oneof",
 		OneOf: "yes;no",
 	}
@@ -41,7 +41,7 @@ func ExampleNewQuotedOneOfGenerator_uniform() {
 }
 
 func ExampleNewQuotedOneOfGenerator_weighted() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type:  "string/oneof",
 		OneOf: "yes:98;no:1;maybe:1",
 	}

--- a/internal/generators/string.go
+++ b/internal/generators/string.go
@@ -13,7 +13,7 @@ type stringGenerator struct {
 	all []rune
 }
 
-func NewStringGenerator(args config.Args) Generator {
+func NewStringGenerator(args config.ColumnDef) Generator {
 	all := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 	if len(args.OneOf) > 0 {
 		all = []rune(args.OneOf)

--- a/internal/generators/string_test.go
+++ b/internal/generators/string_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ExampleNewStringGenerator() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type:   "string", // alias for string/rand
 		Length: 15,
 	}
@@ -16,7 +16,7 @@ func ExampleNewStringGenerator() {
 }
 
 func ExampleNewStringGenerator_charset() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type:   "string/rand",
 		Length: 5,
 		OneOf:  " abcd", // choose the charset you want to pick from

--- a/internal/generators/text.go
+++ b/internal/generators/text.go
@@ -39,7 +39,7 @@ type textGenerator struct {
 	len int
 }
 
-func NewTextGenerator(args config.Args) Generator {
+func NewTextGenerator(args config.ColumnDef) Generator {
 	return &textGenerator{
 		rng: newRng(),
 		len: args.Length,

--- a/internal/generators/text_test.go
+++ b/internal/generators/text_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ExampleNewTextGenerator() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type:   "string/text",
 		Length: 50,
 	}

--- a/internal/generators/uuid.go
+++ b/internal/generators/uuid.go
@@ -13,7 +13,7 @@ var uuidGen = uuid.NewString
 type uuidGenerator struct{}
 
 // TODO: add length?
-func NewUuidGenerator(args config.Args) Generator {
+func NewUuidGenerator(args config.ColumnDef) Generator {
 	return &uuidGenerator{}
 }
 

--- a/internal/generators/uuid_test.go
+++ b/internal/generators/uuid_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func ExampleNewUuidGenerator() {
-	args := config.Args{
+	args := config.ColumnDef{
 		Type: "string/uuid",
 	}
 	g, _ := GetGenerator(args)

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -44,7 +44,7 @@ func (im *Importer) EnableFK() error {
 }
 
 func (im *Importer) Import() error {
-	sqlPrefix := fmt.Sprintf("INSERT INTO %s (%s) VALUES ", im.cfg.DbTable, strings.Join(im.cols, ","))
+	sqlPrefix := fmt.Sprintf("INSERT INTO %s (%s) VALUES ", im.cfg.TableName, strings.Join(im.cols, ","))
 
 	for rem := im.cfg.TotalRecords; rem > 0; rem -= im.cfg.BatchSize {
 		log.Printf("loading a batch of max %d out of remaining %d records", im.cfg.BatchSize, rem)

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -13,12 +13,12 @@ import (
 
 type Importer struct {
 	db   *sql.DB
-	cfg  *config.Config
+	cfg  *config.TableDef
 	cols []string
 	gens []generators.Generator
 }
 
-func NewImporter(db *sql.DB, cfg *config.Config) *Importer {
+func NewImporter(db *sql.DB, cfg *config.TableDef) *Importer {
 	im := Importer{db: db, cfg: cfg}
 	im.cols, im.gens = prepareColumnGenerators(cfg.Columns)
 	return &im

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -65,7 +65,7 @@ func min(a, b int) int {
 	return b
 }
 
-func prepareColumnGenerators(columnsConfig map[string]config.Args) (cols []string, gens []generators.Generator) {
+func prepareColumnGenerators(columnsConfig map[string]config.ColumnDef) (cols []string, gens []generators.Generator) {
 	for col := range columnsConfig {
 		cols = append(cols, col)
 	}

--- a/test/testdata/config-example.yaml
+++ b/test/testdata/config-example.yaml
@@ -1,8 +1,6 @@
-DbDSN: <user>:<password>@tcp(localhost:28000)/bitstamp_dev?parseTime=true&interpolateParams=true
-DbTable: account_walletdeposit
+TableName: account_walletdeposit
 TotalRecords: 5031
 BatchSize: 700
-SafeImport: no
 Columns:
   user_id:
     type: int/uniform


### PR DESCRIPTION
Separate command run arguments from table definitions.

An alternative would be to implement (complex) logic for parsing, validating, and merging multiple YAML config files. This is a much smaller change but still an improvement.